### PR TITLE
Injects inline CSS variables on admin pages

### DIFF
--- a/saplings_custom.info.yml
+++ b/saplings_custom.info.yml
@@ -3,3 +3,5 @@ type: module
 description: 'Custom functionality for the Saplings site starter.'
 package: Saplings
 core_version_requirement: ^10
+dependencies:
+  - ui_skins:ui_skins

--- a/saplings_custom.module
+++ b/saplings_custom.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\node\NodeInterface;
+use Drupal\ui_skins\HookHandler\PageTop;
 
 /**
  * Implements hook_preprocess_html() for html templates.
@@ -33,5 +34,18 @@ function saplings_custom_preprocess_html(array &$variables) {
         ];
       }
     }
+  }
+}
+
+/**
+ * Implements hook_page_top().
+ */
+function saplings_custom_page_top(array &$page_top): void {
+  if (\Drupal::service('router.admin_context')->isAdminRoute()) {
+    $default_theme = \Drupal::config('system.theme')->get('default');
+    // /** @var \Drupal\ui_skins\HookHandler\PageTop $instance */
+    $instance = \Drupal::service('class_resolver')
+      ->getInstanceFromDefinition(PageTop::class);
+    $instance->alter($page_top, $default_theme);
   }
 }


### PR DESCRIPTION
## Description
Teamwork Ticket(s): https://kanopi.teamwork.com/app/tasks/29543155

This ensures the inline CSS variables are injected to the admin theme as well.

## Acceptance Criteria
* CSS variable overrides are injected on admin pages
* CKEditor5 styles match the default theme look.
* e.g. Clicking on a new accordion tab will not close open tabs

## Assumptions
* The patch from this issue is added to your composer main file: https://www.drupal.org/project/ui_skins/issues/3468192

## Steps to Validate
1. Add a button style to a link through CKEditor.
2. Ensure the output style matches the frontend theme.

