### PR TITLE
removes env ribbon from frontend editing form

### DIFF
--- a/saplings_custom.module
+++ b/saplings_custom.module
@@ -35,3 +35,33 @@ function saplings_custom_preprocess_html(array &$variables) {
     }
   }
 }
+
+/**
+ * Implements hook_page_attachments().
+ */
+function saplings_custom_page_attachments(array &$attachments) {
+  // Remove environment_indicator_ribbon library and settings from the frontend
+  // editing form to avoid overlapping.
+  $module_handler = \Drupal::moduleHandler();
+  if (!$module_handler->moduleExists('environment_indicator_ribbon')) {
+    return;
+  }
+
+  $route_match = \Drupal::routeMatch();
+  $route_name = $route_match->getRouteName();
+  if ($route_name !== 'frontend_editing.form') {
+    return;
+  }
+
+  $attached = &$attachments['#attached'];
+
+  // Unattach library and settings as added by the environment_indicator_ribbon
+  // module. @see environment_indicator_ribbon_page_attachments().
+  unset($attached['drupalSettings']['environment_indicator_ribbon']);
+  if (isset($attached['library'])) {
+    $attached['library'] = array_diff(
+      $attached['library'],
+      ['environment_indicator_ribbon/environment_indicator_ribbon']
+    );
+  }
+}


### PR DESCRIPTION
## Description

> As a content editor, I can edit using front-end editing without the environment ribbon getting in the way.

Removes the environment indicator ribbon from the front-end editing form to avoid it overlapping fields and making them hard to edit.

## Motivation

It drove me nuts enough that I wanted it gone. Feel free to Close if you prefer to have it there.

Before:
<img width="1728" height="966" alt="image" src="https://github.com/user-attachments/assets/6757a471-4ce4-4dfa-9630-9757410e9345" />


After:
<img width="1728" height="966" alt="image" src="https://github.com/user-attachments/assets/376311c8-dfcd-4e7a-b887-8ee9845bb690" />


## Acceptance Criteria
* When editing a component using the frontend editing functionality, the ribbon doesn't show up in the form.


## Steps to Validate
1. Edit a paragraph with frontend editing
2. Verify the pesky ribbon is gone from the form
